### PR TITLE
Support for exposing lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 You must build before making a PR!
 
 ## Change Log
+### v0.4
+- Adds the ability to access functions that are created during call to build CustomAPI
+  - You can now access the functions by waiting for the `lambdasReady` promise in the stack file:
+  ```ts
+  const api = new CustomAPI(this, 'TestConstruct', apiProps);
+  api.lambdasReady.then(() => {
+    const testLambda = api.lambdas['testLambda_GET']
+    testLambda.addEnvironment('EXAMPLE', 'value');
+  });
+  ```
+- The created Gateway is also now exposed via the `apiGateway` property
+- The naming convention for lambdas ending with a path value (i.e. `{id}`) has been changed
+  - The lambda will now contain the name of the root parent folder, in addition to the path variable and method
+  - For example, `_id_GET` will now become `test_id_GET` or `example_id_GET`.
+
 ### v0.3
 - Adds two new props, lambdaMemorySize and authorizerMemorySize, to apiProps
 - Allows the user to add any needed function overrides inside of the method config by using `functionProps`. For example, if you wanted to change the memorySize of a specific lambda:

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 export interface methodConfig {
@@ -10,6 +11,15 @@ export interface methodConfig {
             model: any;
         };
     };
+}
+interface apiRoute {
+    routes: {
+        [name: string]: apiRoute;
+    };
+    methods: {
+        [method: string]: any;
+    };
+    resource: apigateway.IResource;
 }
 interface domainConfig {
     baseName?: string;
@@ -32,6 +42,9 @@ export declare class CustomAPI extends Construct {
     authorizers: {
         [key: string]: apigateway.RequestAuthorizer;
     };
+    lambdas: {
+        [key: string]: lambda.Function;
+    };
     environment?: {
         [key: string]: string;
     };
@@ -39,8 +52,12 @@ export declare class CustomAPI extends Construct {
     adminRole: iam.Role;
     lambdaMemorySize: number;
     authorizerMemorySize: number;
+    apiGateway: cdk.aws_apigateway.RestApi;
+    lambdasReady: Promise<void>;
+    private lambdasReadyResolve;
     constructor(scope: Construct, id: string, props: apiProps);
-    addMethod: (type: string, resource: apigateway.IResource, pathToMethod: string, config: any, entry: string, props: apiProps) => Promise<void>;
+    traverse: (currentPath: string, currentNode: apiRoute, props: apiProps, parentName?: string) => Promise<void>;
+    addMethod: (type: string, resource: apigateway.IResource, pathToMethod: string, config: any, methodName: string, props: apiProps) => Promise<void>;
     pathToCamelCase: (path: string) => string;
 }
 export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "path-to-api-construct",
-  "version": "0.1.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "path-to-api-construct",
-      "version": "0.1.2",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "aws-cdk-lib": "^2.124.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path-to-api-construct",
-  "version": "0.1.2",
+  "version": "0.4.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -88,7 +88,7 @@
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    "strictPropertyInitialization": false,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */


### PR DESCRIPTION
- lambdas are now exposed back to where the CustomAPI is called
- created Gateway is also exposed in result
- Updated naming convention for path variable routes