### PR TITLE
v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ You must build before making a PR!
 ## Change Log
 ### v0.5
 - Exposes the `functionProps` on `apiProps` so that you can provide additional function parameters to be applied during creation.
+- Makes `apiProps` usable.
 
 ### v0.4
 - Adds the ability to access functions that are created during call to build CustomAPI

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 You must build before making a PR!
 
 ## Change Log
+### v0.5
+- Exposes the `functionProps` on `apiProps` so that you can provide additional function parameters to be applied during creation.
+
 ### v0.4
 - Adds the ability to access functions that are created during call to build CustomAPI
   - You can now access the functions by waiting for the `lambdasReady` promise in the stack file:

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as nodejsLambda from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
@@ -37,6 +38,7 @@ interface apiProps {
     deployOptions?: apigateway.RestApiProps;
     lambdaMemorySize?: number;
     authorizerMemorySize?: number;
+    functionProps?: nodejsLambda.NodejsFunctionProps;
 }
 export declare class CustomAPI extends Construct {
     authorizers: {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -27,7 +27,7 @@ interface domainConfig {
     name: string;
     certificate: cdk.aws_certificatemanager.Certificate;
 }
-interface apiProps {
+export interface apiProps {
     apiName: string;
     apiFolderPath: string;
     clientHostUrl?: string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -92,7 +92,7 @@ class CustomAPI extends constructs_1.Construct {
             ;
         });
         this.addMethod = (type, resource, pathToMethod, config, methodName, props) => __awaiter(this, void 0, void 0, function* () {
-            const method = new nodejsLambda.NodejsFunction(this, `${methodName}Function`, Object.assign({ runtime: lambda.Runtime.NODEJS_18_X, entry: path.join(pathToMethod, `${type.toLowerCase()}.ts`), environment: this.environment, role: this.adminRole, logRetention: cdk.aws_logs.RetentionDays.ONE_MONTH, functionName: `${cdk.Stack.of(this).stackName}-${methodName}`, timeout: cdk.Duration.seconds(30), memorySize: this.lambdaMemorySize }, config.functionProps));
+            const method = new nodejsLambda.NodejsFunction(this, `${methodName}Function`, Object.assign(Object.assign({ runtime: lambda.Runtime.NODEJS_18_X, entry: path.join(pathToMethod, `${type.toLowerCase()}.ts`), environment: this.environment, role: this.adminRole, logRetention: cdk.aws_logs.RetentionDays.ONE_MONTH, functionName: `${cdk.Stack.of(this).stackName}-${methodName}`, timeout: cdk.Duration.seconds(30), memorySize: this.lambdaMemorySize }, props.functionProps), config.functionProps));
             this.lambdas[methodName] = method;
             let requestModels, requestParameters;
             if (config.model) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "path-to-api-construct",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "path-to-api-construct",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "aws-cdk-lib": "^2.124.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path-to-api-construct",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,7 @@ export class CustomAPI extends Construct {
       functionName: `${cdk.Stack.of(this).stackName}-${methodName}`,
       timeout: cdk.Duration.seconds(30),
       memorySize: this.lambdaMemorySize,
+      ...props.functionProps,
       ...config.functionProps
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ interface apiProps {
   deployOptions?: apigateway.RestApiProps;
   lambdaMemorySize?: number;
   authorizerMemorySize?: number;
+  functionProps?: nodejsLambda.NodejsFunctionProps;
 };
 
 export class CustomAPI extends Construct {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ interface domainConfig {
   certificate: cdk.aws_certificatemanager.Certificate;
 }
 
-interface apiProps {
+export interface apiProps {
   apiName: string;
   apiFolderPath: string;
   clientHostUrl?: string;


### PR DESCRIPTION
- Exposes the `functionProps` on `apiProps` so that you can provide additional function parameters to be applied during creation.
- Makes `apiProps` usable.