### PR TITLE
fix aws-cdk-lib to 2.154.1, export IApiProps

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,3 @@
-export { CustomAPI, methodConfig } from "./ConvertPathToApi";
+export { CustomAPI, IApiProps, methodConfig } from "./ConvertPathToApi";
 export { DatadogInstance } from "./DatadogInstance";
 export { NodejsFunction } from "./NodejsFunction";

--- a/dist/index.js.map
+++ b/dist/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;;AAAA,uDAA6D;AAApD,6GAAA,SAAS,OAAA;AAClB,qDAAoD;AAA3C,kHAAA,eAAe,OAAA;AACxB,mDAAkD;AAAzC,gHAAA,cAAc,OAAA"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;;AAAA,uDAAwE;AAA/D,6GAAA,SAAS,OAAA;AAClB,qDAAoD;AAA3C,kHAAA,eAAe,OAAA;AACxB,mDAAkD;AAAzC,gHAAA,cAAc,OAAA"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
-        "aws-cdk-lib": "^2.150.0",
+        "aws-cdk-lib": "=2.154.1",
         "aws-lambda": "^1.0.7",
         "datadog-cdk-constructs-v2": "^1.16.1"
       },
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.159.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.159.0.tgz",
-      "integrity": "sha512-OzcOuwK11i4xfrcAdDfnALOEBk4tyL257xU9AYTywG7nxQBO7QdawgODcDQV2bXTtNZGZGTH6wwcESNvKk4n8g==",
+      "version": "2.154.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.154.1.tgz",
+      "integrity": "sha512-XV04/XyNKJ2yyMfYsiSmWx+rIKwTrcrd87p61t4xhE240Iy6Y6LxXVdvkNEOjjbeXVmOUQ7JBG9cW1BeeFiDgg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -208,17 +208,17 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^36.0.24",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
+        "@aws-cdk/cloud-assembly-schema": "^36.0.5",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
-        "ignore": "^5.3.2",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.3",
+        "semver": "^7.6.2",
         "table": "^6.8.2",
         "yaml": "1.10.2"
       },
@@ -235,14 +235,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.16.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -334,7 +334,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
       "version": "3.0.1",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
@@ -356,7 +355,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.2",
+      "version": "5.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -447,7 +446,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.6.2",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -518,6 +517,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Nyman Turkish",
   "license": "ISC",
   "dependencies": {
-    "aws-cdk-lib": "^2.150.0",
+    "aws-cdk-lib": "=2.154.1",
     "aws-lambda": "^1.0.7",
     "datadog-cdk-constructs-v2": "^1.16.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { CustomAPI, methodConfig } from "./ConvertPathToApi";
+export { CustomAPI, IApiProps, methodConfig } from "./ConvertPathToApi";
 export { DatadogInstance } from "./DatadogInstance";
 export { NodejsFunction } from "./NodejsFunction";
 


### PR DESCRIPTION
Fixes the CDK lib to `2.154.1` (important to have fixed version between various projects to prevent typing issues). Also re-exports `IApiProps` since this turns out to be pretty useful type.

Once merged I'll create release for 0.6